### PR TITLE
update ci given quarto action update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     # - name: set up ci: quarto, etc.
 
     - name: set up quarto 
-      uses: quarto-dev/quarto-actions/install-quarto@main
+      uses: quarto-dev/quarto-actions/setup@v2
 
     # - name: lint notebooks
 


### PR DESCRIPTION
quarto actions recently updated, which broke our ci as we hadnt pinned.

now using new action format